### PR TITLE
CI/CD인프라 구축 - jdk version 오류 해결

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,10 @@ def dockerPasswd="jihundockerdev"  // 절대 노출 금지
 pipeline {
     agent any
 
+    tools {
+        jdk 'jdk17-arena'
+    }
+
     stages {
         stage('Pull Codes') {
             steps {

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ clean {
 
 jib {
     from {
-        image = 'adoptopenjdk/openjdk11:alpine-jre'
+        image = 'joengenduvel/jre17:alpine3.14'
     }
     container {
         entrypoint = ['java', '-Dspring profiles.active=test', '-jar', 'jenkins-test-0.0.1-SNAPSHOT.jar']


### PR DESCRIPTION
close #13 

- jenkins에서 사용하는 jdk버전보다 애플리케이션 빌드시 사용하는 Jdk 버전이 더 앞서있어 발생한 문제를 해결했습니다.
- Jenkins 컨테이너에서 jdk17을 설치했으며 Jenkins 설정에서 설치한 jdk17에 대한 환경변수 설정헀습니다.
- Jenkinsfile에서는 설정한 jdk17을 기반으로 빌드하도록 tools 필드로 고정했습니다.
- 추가로, Jib 기반 컨테이너 이미지 빌드시 jre를 [17버전](https://hub.docker.com/r/joengenduvel/jre17/tags)으로 사용하도록 baseimage를 변경했습니다.